### PR TITLE
商品の削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
 
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-　before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -35,6 +35,14 @@ def update
   else
     render :edit, status: :unprocessable_entity
   end
+end
+
+def destroy
+  @item = Item.find(params[:id])
+  return redirect_to root_path unless current_user == @item.user
+
+  @item.destroy
+  redirect_to root_path, notice: '商品を削除しました。'
 end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -38,7 +38,6 @@ def update
 end
 
 def destroy
-  @item = Item.find(params[:id])
   return redirect_to root_path unless current_user == @item.user
 
   @item.destroy

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
  <% if user_signed_in? %>
   <% if current_user == @item.user %>
     <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
  <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
    <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
＃What
商品削除機能の作成

＃Why
商品削除機能の実装

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/9a9583a03f8883f0cd65c1df33a1eb33